### PR TITLE
CI: drop ubuntu-18.04

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,7 +20,6 @@ jobs:
           - {dockerfile: 'ubuntu',   tag: 'latest'}
           - {dockerfile: 'ubuntu',   tag: 'rolling',          build_args: 'TAG=rolling'}
           - {dockerfile: 'ubuntu',   tag: 'devel',            build_args: 'TAG=devel', continue-on-error: 'true'}
-          - {dockerfile: 'ubuntu',   tag: '18.04',            build_args: 'TAG=18.04'}
           - {dockerfile: 'opensuse', tag: 'latest'}
           - {dockerfile: 'fedora',   tag: 'intel',            build_args: 'TAG=intel'}
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't use that image anywhere and after https://github.com/ECP-copa/Cabana/pull/510 it won't work anymore, so let's drop it now.